### PR TITLE
Parse H and V commands

### DIFF
--- a/lib/sdf.js
+++ b/lib/sdf.js
@@ -147,6 +147,12 @@ function pathToRings(path) {
             ring = [[ segment.x, segment.y ]];
         } else if (segment.type == 'L') {
             ring.push([ segment.x, segment.y ]);
+        } else if (segment.type == 'H') {
+            var prev = ring.slice(-1)[0];
+            ring.push([ segment.x, prev[1] ]);
+        } else if (segment.type == 'V') {
+            var prev = ring.slice(-1)[0];
+            ring.push([ prev[0], segment.y ])
         } else if (segment.type == 'Q') {
             var prev = ring.pop();
             curve3.init(prev[0], prev[1], segment.x1, segment.y1, segment.x, segment.y);


### PR DESCRIPTION
This adds support for H and V path commands from SVGs. These commands create a line from the current point to the given point on the horizontal or vertical axis, respectively.

This is needed for the SDF sprite generation in the [elastic fork of spritezero](https://github.com/nickpeihl/spritezero/blob/sdf-option/package.json#L18).